### PR TITLE
Add support for refreshing Bunkum's internal state after a hot reload

### DIFF
--- a/Bunkum.HttpServer/BunkumContext.cs
+++ b/Bunkum.HttpServer/BunkumContext.cs
@@ -11,6 +11,7 @@ public enum BunkumContext
     Filter,
     Digest,
     
+    Server,
     Service,
     Middleware,
     Request,

--- a/Bunkum.HttpServer/BunkumHttpServer.cs
+++ b/Bunkum.HttpServer/BunkumHttpServer.cs
@@ -11,6 +11,7 @@ using Bunkum.HttpServer.Database;
 using Bunkum.HttpServer.Database.Dummy;
 using Bunkum.HttpServer.Endpoints;
 using Bunkum.HttpServer.Endpoints.Middlewares;
+using Bunkum.HttpServer.HotReload;
 using Bunkum.HttpServer.Services;
 using NotEnoughLogs;
 using NotEnoughLogs.Loggers;
@@ -22,16 +23,14 @@ namespace Bunkum.HttpServer;
 /// </summary>
 [SuppressMessage("ReSharper", "UnusedMember.Global")]
 [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
-public partial class BunkumHttpServer
+public partial class BunkumHttpServer : IHotReloadable, IDisposable
 {
     private readonly BunkumHttpListener _listener;
-    private readonly List<EndpointGroup> _endpoints = new();
     private readonly LoggerContainer<BunkumContext> _logger;
     
     private IDatabaseProvider<IDatabaseContext> _databaseProvider = new DummyDatabaseProvider();
-    
     private readonly List<Config> _configs;
-
+    private readonly List<EndpointGroup> _endpoints = new();
     private readonly List<IMiddleware> _middlewares = new();
     private readonly List<Service> _services = new();
 
@@ -61,6 +60,8 @@ public partial class BunkumHttpServer
         {
             this._listener = null!;
         }
+        
+        BunkumHotReloadableRegistry.RegisterReloadable(this);
     }
 
     public BunkumHttpServer() : this(true, true) {}
@@ -281,6 +282,41 @@ public partial class BunkumHttpServer
         }
     }
 
+    private Action? _initialize;
+    public Action? Initialize
+    {
+        private get => this._initialize;
+        set
+        {
+            if (value == null) throw new InvalidOperationException("Cannot set a null initializer");
+            this._initialize = value;
+            
+            this._initialize.Invoke();
+        }
+    }
+
+    void IHotReloadable.ProcessHotReload()
+    {
+        // If there's no initialization function, we can't do anything without destroying the server.
+        if (this.Initialize == null) return;
+
+        // Back up the current BunkumConfig
+        BunkumConfig? bunkumConfig = (BunkumConfig?)this._configs.FirstOrDefault(c => c is BunkumConfig);
+        Debug.Assert(bunkumConfig != null);
+        
+        // Clear current internal state
+        this._configs.Clear();
+        this._configs.Add(bunkumConfig);
+        
+        this._endpoints.Clear();
+        this._services.Clear();
+        this._middlewares.Clear();
+        this._databaseProvider.Dispose();
+        
+        // Refresh internal state using (potentially new) initialization function
+        this.Initialize.Invoke();
+    }
+
     private void AddEndpointGroup(Type type)
     {
         EndpointGroup? doc = (EndpointGroup?)Activator.CreateInstance(type);
@@ -328,4 +364,12 @@ public partial class BunkumHttpServer
 
     public void AddMiddleware<TMiddleware>() where TMiddleware : IMiddleware, new() => this.AddMiddleware(new TMiddleware());
     public void AddMiddleware<TMiddleware>(TMiddleware middleware) where TMiddleware : IMiddleware => this._middlewares.Add(middleware);
+
+    // we don't handle full disposal
+#pragma warning disable CA1816
+    public void Dispose()
+#pragma warning restore CA1816
+    {
+        BunkumHotReloadableRegistry.UnregisterReloadable(this);
+    }
 }

--- a/Bunkum.HttpServer/BunkumHttpServer.cs
+++ b/Bunkum.HttpServer/BunkumHttpServer.cs
@@ -288,6 +288,7 @@ public partial class BunkumHttpServer : IHotReloadable, IDisposable
         private get => this._initialize;
         set
         {
+            if (this._initialize != null) throw new InvalidOperationException("Initializer has already been set.");
             if (value == null) throw new InvalidOperationException("Cannot set a null initializer");
             this._initialize = value;
             

--- a/Bunkum.HttpServer/BunkumHttpServer.cs
+++ b/Bunkum.HttpServer/BunkumHttpServer.cs
@@ -23,7 +23,7 @@ namespace Bunkum.HttpServer;
 /// </summary>
 [SuppressMessage("ReSharper", "UnusedMember.Global")]
 [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
-public partial class BunkumHttpServer : IHotReloadable, IDisposable
+public partial class BunkumHttpServer : IHotReloadable
 {
     private readonly BunkumHttpListener _listener;
     private readonly LoggerContainer<BunkumContext> _logger;
@@ -195,10 +195,13 @@ public partial class BunkumHttpServer : IHotReloadable, IDisposable
 
     /// <summary>
     /// Attempts to stop all block tasks, including those managed by the caller.
+    /// 
+    /// If you are creating a server that does not span across the entire lifetime of the application, you are responsible for calling this to stop the server.
     /// </summary>
     public void Stop()
     {
         this._stopToken.Cancel();
+        BunkumHotReloadableRegistry.UnregisterReloadable(this);
     }
 
     private async Task HandleRequest(ListenerContext context, Lazy<IDatabaseContext> database)
@@ -376,12 +379,4 @@ public partial class BunkumHttpServer : IHotReloadable, IDisposable
 
     public void AddMiddleware<TMiddleware>() where TMiddleware : IMiddleware, new() => this.AddMiddleware(new TMiddleware());
     public void AddMiddleware<TMiddleware>(TMiddleware middleware) where TMiddleware : IMiddleware => this._middlewares.Add(middleware);
-
-    // we don't handle full disposal
-#pragma warning disable CA1816
-    public void Dispose()
-#pragma warning restore CA1816
-    {
-        BunkumHotReloadableRegistry.UnregisterReloadable(this);
-    }
 }

--- a/Bunkum.HttpServer/HotReload/BunkumHotReloadableRegistry.cs
+++ b/Bunkum.HttpServer/HotReload/BunkumHotReloadableRegistry.cs
@@ -1,0 +1,40 @@
+namespace Bunkum.HttpServer.HotReload;
+
+/// <summary>
+/// A registry containing objects that can be hot reloaded.
+/// </summary>
+internal static class BunkumHotReloadableRegistry
+{
+    private static readonly List<IHotReloadable> HotReloadableObjects = new(1);
+
+    internal static void ProcessHotReload()
+    {
+        Console.WriteLine("Hot reload!");
+        Console.WriteLine($"- Processing {HotReloadableObjects.Count} reloadable objects");
+        int i = 0;
+        foreach (IHotReloadable reloadable in HotReloadableObjects)
+        {
+            i++;
+            Console.WriteLine($"  ({i}/{HotReloadableObjects.Count}) Reloading {reloadable.GetType().Name}...");
+            reloadable.ProcessHotReload();
+        }
+        
+        Console.WriteLine("Done hot reloading.");
+    }
+
+    /// <summary>
+    /// Register a reloadable object, signing it up to receive an event when a hot reload occurs.
+    /// </summary>
+    internal static void RegisterReloadable(IHotReloadable reloadable)
+    {
+        HotReloadableObjects.Add(reloadable);
+    }
+
+    /// <summary>
+    /// Remove a reloadable object from the registry. Call this when the object is disposed or collected.
+    /// </summary>
+    internal static void UnregisterReloadable(IHotReloadable reloadable)
+    {
+        HotReloadableObjects.Remove(reloadable);
+    }
+}

--- a/Bunkum.HttpServer/HotReload/BunkumHotReloadableRegistry.cs
+++ b/Bunkum.HttpServer/HotReload/BunkumHotReloadableRegistry.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace Bunkum.HttpServer.HotReload;
 
 /// <summary>
@@ -9,17 +11,17 @@ internal static class BunkumHotReloadableRegistry
 
     internal static void ProcessHotReload()
     {
-        Console.WriteLine("Hot reload!");
-        Console.WriteLine($"- Processing {HotReloadableObjects.Count} reloadable objects");
+        Debug.WriteLine("Hot reload!");
+        Debug.WriteLine($"- Processing {HotReloadableObjects.Count} reloadable objects");
         int i = 0;
         foreach (IHotReloadable reloadable in HotReloadableObjects)
         {
             i++;
-            Console.WriteLine($"  ({i}/{HotReloadableObjects.Count}) Reloading {reloadable.GetType().Name}...");
+            Debug.WriteLine($"  ({i}/{HotReloadableObjects.Count}) Reloading {reloadable.GetType().Name}...");
             reloadable.ProcessHotReload();
         }
         
-        Console.WriteLine("Done hot reloading.");
+        Debug.WriteLine("Done hot reloading.");
     }
 
     /// <summary>

--- a/Bunkum.HttpServer/HotReload/BunkumMetadataUpdateHandler.cs
+++ b/Bunkum.HttpServer/HotReload/BunkumMetadataUpdateHandler.cs
@@ -1,0 +1,24 @@
+using System.Reflection.Metadata;
+using Bunkum.HttpServer.HotReload;
+using JetBrains.Annotations;
+
+[assembly: MetadataUpdateHandler(typeof(BunkumMetadataUpdateHandler))]
+
+namespace Bunkum.HttpServer.HotReload;
+
+/// <summary>
+/// A receiver for updates of type metadata.
+/// For more information, see https://learn.microsoft.com/en-us/dotnet/api/system.reflection.metadata.metadataupdatehandlerattribute
+/// </summary>
+internal class BunkumMetadataUpdateHandler
+{
+    /// <summary>
+    /// Called when a hot reload is triggered and the program's metadata has updated.
+    /// </summary>
+    /// <param name="updatedTypes">The types affected by the metadata update. If null, any type may have been updated.</param>
+    [UsedImplicitly]
+    public static void UpdateApplication(Type[]? updatedTypes)
+    {
+        BunkumHotReloadableRegistry.ProcessHotReload();
+    } 
+}

--- a/Bunkum.HttpServer/HotReload/IHotReloadable.cs
+++ b/Bunkum.HttpServer/HotReload/IHotReloadable.cs
@@ -1,0 +1,6 @@
+namespace Bunkum.HttpServer.HotReload;
+
+internal interface IHotReloadable
+{
+    internal void ProcessHotReload();
+}

--- a/BunkumTests.HttpServerManual/Program.cs
+++ b/BunkumTests.HttpServerManual/Program.cs
@@ -4,9 +4,13 @@ using BunkumTests.HttpServer;
 BunkumConsole.AllocateConsole();
 
 BunkumHttpServer server = new();
-server.AddHealthCheckService();
-server.DiscoverEndpointsFromAssembly(typeof(ServerDependentTest).Assembly);
+server.Initialize = () =>
+{
+    server.AddHealthCheckService();
+    server.DiscoverEndpointsFromAssembly(typeof(ServerDependentTest).Assembly);
+};
 
 // await server.StartAndBlockAsync();
 server.Start();
+
 await Task.Delay(-1);


### PR DESCRIPTION
This PR adds a new `Action` property to `BunkumHttpServer`. As described in #19, this new Action can be defined by the user. It should contain initialization code (adding endpoints, services, etc.) and is invoked when the property is set.

The advantage is that in addition to running on startup, the new Action will be invoked after a hot reload and a clearing of Bunkum's internal state. This means that the initialization code can be modified and tweaked as an application runs, and Bunkum will re-run it each time with a clean slate and no downtime. You can also use this to add new Endpoints/Services to a Bunkum server.

This is **not** a breaking change, as Bunkum allows services/endpoints to be added at runtime by design. Rather, it is a clever use of how Bunkum operates internally. The old traditional method of initializing Bunkum by operating on the `BunkumHttpServer` in `Program.cs` will still work, but there will be a warning when a hot reload is performed without the new initialization method.